### PR TITLE
Update IntroText.1.4.tga

### DIFF
--- a/Data/SourceAssets/Localization/English/IntroText.1.4.tga
+++ b/Data/SourceAssets/Localization/English/IntroText.1.4.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c2395bfd606463fb68fc664f20f8a3a58a0ac2912289337f9080b8f21da865f
-size 36054
+oid sha256:13db539d0da87df60af0250e3ff153b05adbc1b08a0334c9a4453b594be4de95
+size 36080


### PR DESCRIPTION
re-saved fburn logo without RLE compression. Might fix the broken image display mentioned in the BUGS section